### PR TITLE
added moment to intern packages

### DIFF
--- a/generators/app/templates/tests/intern.js
+++ b/generators/app/templates/tests/intern.js
@@ -69,6 +69,8 @@ define({
 		}, {
 			name: 'dmodel', location: 'dist/dmodel'
 		}, {
+			name: 'moment', location: 'dist/moment'
+		}, {
 			name: 'xstyle', location: 'dist/xstyle'
 		}, {
 			name: 'put-selector', location: 'dist/put-selector'


### PR DESCRIPTION
I was getting an error while running the intern test page, looking at the http-server logs, I noticed that intern couldn't find moment js, and I then noticed it was missing from intern's packages array. This seemed to fix it.
