### PR TITLE
remove new lines from output package.json

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -23,25 +23,19 @@
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-connect": "^1.0.2",
     "grunt-contrib-copy": "^1.0.0",
-    "grunt-contrib-cssmin": "^1.0.1",
-    <% if (stylus) { %>
-    "grunt-contrib-stylus": "^1.2.0",
-    <% } %>
+    "grunt-contrib-cssmin": "^1.0.1",<% if (stylus) { %>
+    "grunt-contrib-stylus": "^1.2.0",<% } %>
     "grunt-contrib-watch": "^1.0.0",
     "grunt-css-url-copy": "^1.0.1",
     "grunt-eslint": "^19.0.0",
     "grunt-http-server": "^2.0.0",
     "grunt-injector": "^1.0.1",
     "grunt-pagespeed": "^2.0.1",
-    "grunt-processhtml": "^0.4.0",
-    <% if (sass) { %>
-    "grunt-sass": "^1.2.0",
-    <% } %>
+    "grunt-processhtml": "^0.4.0",<% if (sass) { %>
+    "grunt-sass": "^1.2.0",<% } %>
     "grunt-shell": "^1.3.0",
-    "grunt-static-inline": "^0.1.6",
-    <% if (v4) { %>
-    "grunt-string-replace": "^1.2.1",
-    <% } %>
+    "grunt-static-inline": "^0.1.6",<% if (v4) { %>
+    "grunt-string-replace": "^1.2.1",<% } %>
     "matchdep": "^1.0.1",
     "uglify-js": "^2.7.0"
   },


### PR DESCRIPTION
this change ensures there are no blank lines in output `package.json`

``` json
"grunt-contrib-connect": "^1.0.2",
"grunt-contrib-copy": "^1.0.0",
"grunt-contrib-cssmin": "^1.0.1",

"grunt-contrib-stylus": "^1.2.0",

"grunt-contrib-watch": "^1.0.0",
"grunt-css-url-copy": "^1.0.1",
```

the formatting of my proposed conditional blocks are definitely less readable, so no offense if you decide you'd rather just leave things the way they are.
